### PR TITLE
Remove order

### DIFF
--- a/dist/common-manifest-template.json
+++ b/dist/common-manifest-template.json
@@ -19,7 +19,7 @@
     "default_icon": "icons/icon.png"
   },
 
-  "permissions": ["activeTab", "storage"],
+  "permissions": ["activeTab"],
 
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self';"

--- a/dist/common-manifest-template.json
+++ b/dist/common-manifest-template.json
@@ -8,7 +8,7 @@
 
   "content_scripts": [
     {
-      "matches": ["http://*.messenger.com/*", "https://*.messenger.com/*"],
+      "matches": ["https://*.messenger.com/*"],
       "js": ["main.js"],
       "run_at": "document_end"
     }

--- a/dist/common-manifest-template.json
+++ b/dist/common-manifest-template.json
@@ -8,7 +8,7 @@
 
   "content_scripts": [
     {
-      "matches": ["https://*.messenger.com/*"],
+      "matches": ["https://*.facebook.com/messages/*", "https://*.messenger.com/*"],
       "js": ["main.js"],
       "run_at": "document_end"
     }

--- a/dist/common-manifest-template.json
+++ b/dist/common-manifest-template.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Fire Messenger",
   "description": "This extension sequentially unsends all messages in a messenger chain.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "abdallah-eldali",
   "homepage_url": "https://github.com/abdallah-eldali/fire-messenger",
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,9 +2,12 @@
 
 #This script automatically creates the packages for the extension for both chrome and firefox and places them in build/ directory
 package_extension() {
-  jq -s '.[0] * .[1]' ./dist/common-manifest-template.json ./dist/$1/$1-manifest-template.json > ./src/manifest.json
 
-  name=$(jq '.name' ./src/manifest.json | tr '[:upper:]' '[:lower:]' | tr -s ' ' '-' | tr -d '"') 
+  mkdir -p ./tmp
+
+  jq -s '.[0] * .[1]' ./dist/common-manifest-template.json ./dist/$1/$1-manifest-template.json > ./tmp/manifest.json
+
+  name=$(jq '.name' ./tmp/manifest.json | tr '[:upper:]' '[:lower:]' | tr -s ' ' '-' | tr -d '"')
 
   options=''
   if [ $1 = 'firefox' ]; then
@@ -15,12 +18,17 @@ package_extension() {
     options='--exclude *.svg'
   fi
 
-  (cd ./src/ ; zip -r -FS ../build/$1_$name.zip * $options ; cd -)
+  cp -r ./src/* ./tmp/
+
+  if [ $1 = 'firefox' ]; then
+    sed -i '/browser-polyfill.js/d' ./tmp/popup.html
+  fi
+
+  (cd ./tmp/ ; zip -r -FS ../build/$1_$name.zip * $options ; cd -)
+  rm -rf ./tmp/
 }
 
 mkdir -p ./build
 
 package_extension firefox
 package_extension chrome
-
-rm -f ./src/manifest.json

--- a/src/main.js
+++ b/src/main.js
@@ -58,11 +58,11 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, randomizedSleep));
 }
 
-Node.prototype.waitForQuerySelector = function(query, timeout) {
+Node.prototype.waitForQuerySelector = function(query, timeout, matchInnerText=".*") {
   return new Promise((resolve, reject) => {
     const time_interval = 100;
     let intervalId = setInterval(() => {
-      let element = this.querySelector(query);
+      let element = Array.from(this.querySelectorAll(query)).find((el) => el.innerText?.match(matchInnerText));
       if (element || timeout <= 0) {
         clearInterval(intervalId);
         resolve(element); //will return element or null
@@ -222,8 +222,8 @@ async function unsendMessage(chat_msg) {
 
   //await sleep(500);
   // Hit unsend on the popup. If we are in debug mode, just log the popup.
-  const unsendButton = await document.waitForQuerySelector(REMOVE_CONFIRMATION_QUERY, 5000);
-  const cancelButton = await document.waitForQuerySelector(CANCEL_CONFIRMATION_QUERY, 5000);
+  const unsendButton = await document.waitForQuerySelector(REMOVE_CONFIRMATION_QUERY, 5000, "Remove");
+  const cancelButton = await document.waitForQuerySelector(CANCEL_CONFIRMATION_QUERY, 5000, "Cancel");
   // This means the window asking to unsend the messages isn't open
   if (!unsendButton && !cancelButton) {
     console.log("No unsendButton and cancelButton! Unsending window might not been opened. Skipping holder: ", chat_msg);

--- a/src/main.js
+++ b/src/main.js
@@ -49,11 +49,6 @@ let DELAY = 5;
 const RUNNER_COUNT = 10;
 const DEBUG_MODE = false; // When set, does not actually remove messages.
 
-const currentURL =
-  location.protocol + '//' + location.host + location.pathname;
-const continueKey = 'fire-messenger-continue' + currentURL;
-const delayKey = 'fire-messenger-delay' + currentURL;
-
 let scrollerCache = null;
 const clickCountPerElement = new Map();
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,13 +6,13 @@
 // You're friends on facebook
 // Lives in {city/state}
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=
-TOP_OF_CHAIN_QUERY = '.xsag5q8.xn6708d.x1ye3gou.x1cnzs8';
+TOP_OF_CHAIN_QUERY = `.xsag5q8.xn6708d.x1ye3gou.x1cnzs8`;
 
 // Remove Queries -------------------------------------------------------------
-MY_ROW_QUERY = '.x78zum5.xdt5ytf.x193iq5w.x1n2onr6.xuk3077'; // Also used for finding the scroller (we just go up to the first parent w/ scrollTop)
+MY_ROW_QUERY = `.x78zum5.xdt5ytf.x193iq5w.x1n2onr6.xuk3077`; // Also used for finding the scroller (we just go up to the first parent w/ scrollTop)
 
 // Partner chat text innerText.
-PARTNER_CHAT_QUERY = '.x1cy8zhl.x78zum5.xdt5ytf.x193iq5w.x1n2onr6.x1kxipp6';
+PARTNER_CHAT_QUERY = `.x1cy8zhl.x78zum5.xdt5ytf.x193iq5w.x1n2onr6.x1kxipp6`;
 
 // Selects all sent chats (both Partner's and User's chat messages)
 CHATS_QUERY = `.html-div.xdj266r.x11i5rnm.xat24cr.x1mh8g0r.xexx8yu.x4uap5.x18d9i69.xkhd6sd.x78zum5.xh8yej3:has(${MY_ROW_QUERY},${PARTNER_CHAT_QUERY})`;
@@ -23,48 +23,82 @@ UNSENT_MESSAGE_QUERY = `.html-div.xdj266r.x11i5rnm.xat24cr.x1mh8g0r.xexx8yu.x4ua
 ALL_CHAT_QUERY = `${CHATS_QUERY},${UNSENT_MESSAGE_QUERY}`;
 
 // The sideways ellipses used to open the 'remove' menu. Visible on hover.
-MORE_BUTTONS_QUERY = '[role="row"] [aria-hidden="false"] [aria-label="More"]';
+MORE_BUTTONS_QUERY = `[role="row"] [aria-hidden="false"] [aria-label="More"]`;
 
 // The button used to open the remove confirmation dialog.
-REMOVE_BUTTON_QUERY = '[aria-label="Remove message"],[aria-label="Remove Message"]';
-
-// The button used to close the 'message removed' post confirmation.
-OKAY_BUTTON_QUERY = '[aria-label="Okay"]';
-
-REMOVE_CONFIRMATION_QUERY = '[aria-label="Unsend"],[aria-label="Remove"]';
+REMOVE_BUTTON_QUERY = `[aria-label="Remove message"],[aria-label="Remove Message"]`;
+REMOVE_CONFIRMATION_QUERY = `[aria-label="Unsend"],[aria-label="Remove"]`;
 CANCEL_BUTTON_QUERY = `:not([aria-disabled="true"])[aria-label="Cancel"][role="button"]`
 CANCEL_CONFIRMATION_QUERY = `[aria-label="Who do you want to unsend this message for?"] ${CANCEL_BUTTON_QUERY},[aria-label="Remove for you"] ${CANCEL_BUTTON_QUERY}`;
 
 // The loading animation.
-LOADING_QUERY = '[role="main"] svg[aria-valuetext="Loading..."]';
+LOADING_QUERY = `[role="main"] svg[aria-valuetext="Loading..."]`;
 
 // Consts and Params.
 const STATUS = {
-  CONTINUE: 'continue',
-  ERROR: 'error',
-  COMPLETE: 'complete',
+  CONTINUE: "continue",
+  ERROR: "error",
+  COMPLETE: "complete",
+  STOPPED: "stopped"
 };
 
 let DELAY = 5;
-const RUNNER_COUNT = 10;
+let STOP = false;
 const DEBUG_MODE = false; // When set, does not actually remove messages.
 
 let scrollerCache = null;
-const clickCountPerElement = new Map();
 
 // Helper functions ----------------------------------------------------------
-function getRandom(min, max) {
-  // min and max included
-  return Math.floor(Math.random() * (max - min + 1) + min);
-}
-
 function sleep(ms) {
+  function getRandom(min, max) {
+    // min and max included
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  }
   let randomizedSleep = getRandom(ms, ms * 1.33);
   return new Promise((resolve) => setTimeout(resolve, randomizedSleep));
 }
 
-function reload() {
-  window.location = window.location.pathname;
+Node.prototype.waitForQuerySelector = function(query, timeout) {
+  return new Promise((resolve, reject) => {
+    const time_interval = 100;
+    let intervalId = setInterval(() => {
+      let element = this.querySelector(query);
+      if (element || timeout <= 0) {
+        clearInterval(intervalId);
+        resolve(element); //will return element or null
+      }
+      //if (element) {
+      //  clearInterval(intervalId);
+      //  resolve(element);
+      //}
+      //if (timeout <= 0) {
+      //  console.log("Timeout");
+      //  clearInterval(intervalId);
+      //  reject("Timeout");
+      //}
+      timeout -= time_interval;
+    }, time_interval);
+  });
+}
+
+// Constantly polls for the Node to check if it's connected to the DOM until timeout in milliseconds
+Node.prototype.waitForDisconnect = function(timeout) {
+  return new Promise((resolve, reject) => {
+    const time_interval = 100;
+    let intervalId = setInterval(() => {
+      if (!this.isConnected || timeout <= 0) {
+        clearInterval(intervalId);
+        resolve(!this.isConnected);
+      }
+      timeout -= time_interval;
+    }, time_interval);
+  });
+}
+
+function getMostRecentMessage() {
+  const elementsToUnsend = Array.from(document.querySelectorAll(ALL_CHAT_QUERY)).at(-1);
+  console.log("Got most recent message element to unsend: ", elementsToUnsend);
+  return elementsToUnsend;
 }
 
 function getScroller() {
@@ -72,18 +106,18 @@ function getScroller() {
 
   let el;
   try {
-    el = document.querySelector(ALL_CHAT_QUERY);
-    while (!('scrollTop' in el) || el.scrollTop === 0) {
-      console.log('Traversing tree to find scroller...', el);
+    el = getMostRecentMessage();
+    while (!("scrollTop" in el) || el.scrollTop === 0) {
+      console.log("Traversing tree to find scroller...", el);
       el = el.parentElement;
     }
   } catch (e) {
     alert(
-      'Could not find scroller. This normally happens because you do not ' +
-        'have enough messages to scroll through. Failing.',
+      "Could not find scroller. This normally happens because you do not " +
+        "have enough messages to scroll through. Failing.",
     );
-    console.log('Could not find scroller; failing.');
-    throw new Error('Could not find scroller.');
+    console.log("Could not find scroller; failing.");
+    throw new Error("Could not find scroller.");
   }
 
   scrollerCache = el;
@@ -94,175 +128,206 @@ function getScroller() {
 // Takes a chat message and removes any reaction made by the user
 // Returns true if the user didn't react to the chat or the reaction was removed successfully, false otherwise
 async function removeReactionFromMessage(chat_msg) {
+  if (!chat_msg) {
+    console.log(`Chat Message doesn't exist: ${chat_msg}`);
+    return false;
+  }
+
+  chat_msg.scrollIntoView();
+
   // Get the reactions from chat message
-  const reactionButton = chat_msg.parentElement.querySelector(`[aria-label*="see who reacted to this"][role="button"]`);
+  const reactionButton = chat_msg.parentElement?.querySelector(`[aria-label*="see who reacted to this"][role="button"]`);
   if (!reactionButton) {
-    console.log('Chat message has no reaction');
+    console.log("Chat message has no reaction");
     return true;
   }
-  console.log('Clicking on reaction button: ', reactionButton);
-  reactionButton.click();
-  await sleep(500);
 
+  console.log("Clicking on reaction button: ", reactionButton);
+  reactionButton.click();
+  await sleep(500); // NOTE: This sleep is important, DO NOT user waitForQuerySelector alone to get the window popup as it will return the loading popup window instead of the already loaded one
   // Check if the reaction window has opened
-  const windowPopup = document.querySelector(`.x1yr2tfi`);
+  const windowPopup = await document.waitForQuerySelector(".x1yr2tfi", 3000);
   // Check if the title tag within the popup window is of "Message reactions"
-  if (windowPopup?.querySelector('.x1lkfr7t').innerText !== 'Message reactions') {
+  if (windowPopup?.querySelector(".x1lkfr7t")?.innerText !== "Message reactions") {
     console.log("Reaction window couldn't open");
     return false;
   }
 
+  let userReacted = false;
   // Find if the user reacted to the message
   // NOTE: I'm not sure if a user can react to a message more than once, if not, then this array will always only have one element at most
   Array.from(windowPopup.querySelectorAll(`div.xu06os2:nth-child(2) > span`))
-       .filter((el) => el.innerText === 'Click to remove')
+       .filter((el) => el.innerText === "Click to remove")
        .forEach(async (el) => {
          if (DEBUG_MODE) {
-           console.log('Skipping removal of reaction we are in debug mode. ', el);
+           console.log("Skipping removal of reaction we are in debug mode. ", el);
            return; // counts as a 'continue' keyword
          }
 
-         console.log('Removing reaction from message: ', el);
+         console.log("Removing reaction from message: ", el);
          el.click();
-         await sleep(150);
+         //await sleep(500);
+         userReacted = true;
        });
 
   // Close reaction window
-  console.log('Closing reaction window');
+  console.log("Closing reaction window");
+  //await sleep(500);
   windowPopup.querySelector(`[aria-label="Close"][role="button"]`).click();
-  await sleep(1000);
-  return true;
+  //await sleep(500);
+  if (!userReacted) return true;
+
+  if (!chat_msg.parentElement.querySelector(`[aria-label*="see who reacted to this"][role="button"]`)) {
+      console.log("Reaction was successfully removed");
+      return true;
+  }
+  console.log("Reaction wasn't successfully removed");
+  return false;
 }
 
-
-async function prepareDOMForRemoval() {
-  const elementsToRemove = [];
-
-  // Add the elements from clickCountPerElement where the count is greater than
-  // 3 to elementsToRemove.
-  for (let [el, count] of clickCountPerElement) {
-    if (count > 3) {
-      console.log('Unable to unsend element: ', el);
-      elementsToRemove.push(el);
-    }
+async function unsendMessage(chat_msg) {
+  if (!chat_msg) {
+    console.log("Chat Message doesn't exist: ", chat_msg);
+    return false;
   }
 
-  // Once we know what to remove, start the loading process for new messages
-  // just in case we lose the scroller.
-  getScroller().scrollTop = 0;
-  await sleep(1000);
+  chat_msg.scrollIntoView();
 
-  // We cant delete all of the elements because react will crash. Keep the
-  // first one.
-  elementsToRemove.shift();
-  elementsToRemove.reverse();
-  console.log('Removing bad rows from dom: ', elementsToRemove);
-  for (let badEl of elementsToRemove) {
-    await sleep(100);
-    let el = badEl;
-    try {
-      while (el.getAttribute('role') !== 'row') el = el.parentElement;
-      el.remove();
-    } catch (err) {
-      console.log('Skipping row: could not find the row attribute.');
-    }
+  // Trigger the hover over the chat message
+  console.log("Triggering hover on: ", chat_msg);
+  chat_msg.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+  //await sleep(500);
+
+  // Get the more button of the message (the 3 elipses besides a chat message)
+  const moreButton = await chat_msg.parentElement?.parentElement?.waitForQuerySelector(MORE_BUTTONS_QUERY, 5000);
+  if (!moreButton) {
+    console.log("No More Button found! Skipping holder: ", chat_msg);
+    return false;
+  }
+
+  console.log("Clicking more button: ", moreButton);
+  moreButton.click();
+
+  //await sleep(500);
+  // Hit the remove button to tget the popup
+  const removeButton = await document.waitForQuerySelector(REMOVE_BUTTON_QUERY, 5000);
+  if (!removeButton) {
+    console.log("No Remove Button found! Skipping holder: ", chat_msg);
+    return false;
+  }
+
+  console.log("Clicking remove button: ", removeButton);
+  removeButton.click();
+
+  //await sleep(500);
+  // Hit unsend on the popup. If we are in debug mode, just log the popup.
+  const unsendButton = await document.waitForQuerySelector(REMOVE_CONFIRMATION_QUERY, 5000);
+  const cancelButton = await document.waitForQuerySelector(CANCEL_CONFIRMATION_QUERY, 5000);
+  // This means the window asking to unsend the messages isn't open
+  if (!unsendButton && !cancelButton) {
+    console.log("No unsendButton and cancelButton! Unsending window might not been opened. Skipping holder: ", chat_msg);
+    return false;
+  }
+  if (DEBUG_MODE) {
+    console.log("Skipping unsend because we are in debug mode: ", unsendButton);
+    cancelButton.click();
+    return true;
+  } else if (!unsendButton) {
+    console.log("No unsendButton found! Skipping holder: ", chat_msg);
+    cancelButton.click();
+    return false;
+  } else {
+    console.log("Clicking unsend button: ", unsendButton);
+    unsendButton.click();
+  }
+
+  //await sleep(500);
+  // Check if chat_msg was deleted (is it still connected to the DOM?)
+  const isMessageDisconnectedFromDOM = await chat_msg.waitForDisconnect(1000);
+  return isMessageDisconnectedFromDOM;
+}
+
+function removeElementFromDOM(chat_msg) {
+  try {
+    chat_msg.closest(`div.x78zum5.xdt5ytf.x1iyjqo2.x2lah0s.xl56j7k.x121v3j4 > div`).remove();
+  } catch (err) {
+    console.log("Couldn't remove chat message from DOM. Thowing error");
+    throw err;
   }
 }
 
-async function getAllMessages() {
-  // Get all ... buttons that let you select 'more' for all messages you sent.
-  const elementsToUnsend = [...document.querySelectorAll(ALL_CHAT_QUERY)];
-  console.log('Got elements to unsend: ', elementsToUnsend);
-  return elementsToUnsend;
+function isMessageACall(chat_msg) {
+  if (!chat_msg) {
+    console.log("Chat message doesn't exist: ", chat_msg);
+    return false;
+  }
+
+  if (chat_msg.querySelector(`[aria-label*="call"][role="button"]`)) {
+    console.log("Chat message is a call: ", chat_msg);
+    return true;
+  } else {
+    console.log("Chat message is not a call: ", chat_msg);
+    return false;
+  }
+
+}
+
+function isMessageFromUser(chat_msg) {
+  if (!chat_msg) {
+    throw new Error("Chat Message doesn't exist");
+  }
+  return Boolean(chat_msg.querySelector(MY_ROW_QUERY));
 }
 
 async function unsendAllVisibleMessages() {
-  // Prepare the DOM. Get the elements we can remove. Load the next set. Hide
-  // the rest.
-  prepareDOMForRemoval();
-  const moreButtonsHolders = await getAllMessages();
-  console.log('Found hidden menu holders: ', moreButtonsHolders);
+  const scroller_ = getScroller();
+  while (recentMessage = getMostRecentMessage()) {
+    // Check if we need to stop, if so, return as Complete
+    if (STOP) {
+      return { status: STATUS.STOPPED };
+    }
 
-  // Reverse list so it steps through messages from bottom and not a seemingly
-  // random position.
-  for (el of moreButtonsHolders.slice().reverse()) {
-    // Keep current task in view, as to not confuse users, thinking it's not
-    // working anymore.
-    el.scrollIntoView();
     await sleep(100);
 
+    if (!recentMessage.isConnected) {
+      continue;
+    }
+
+    if (isMessageACall(recentMessage)) {
+      removeElementFromDOM(recentMessage);
+      continue;
+    }
+
     // Remove reactions from chat message if possible
-    if (!(await removeReactionFromMessage(el))) {
-      console.log('Could not successfully remove the reactions! Skipping holder: ', el);
+    if (!isMessageFromUser(recentMessage) &&
+        !(await removeReactionFromMessage(recentMessage))) {
+      console.log("Could not successfully remove the reactions! Skipping holder: ", recentMessage);
       continue;
     }
-
-    // Trigger on hover.
-    console.log('Triggering hover on: ', el);
-    el.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-    await sleep(150);
-
-    // Get the more button.
-    const moreButton = el.parentElement.parentElement.querySelector(MORE_BUTTONS_QUERY);
-    if (!moreButton) {
-      console.log('No moreButton found! Skipping holder: ', el);
+    // Unsend message from chat if possible
+    if (!(await unsendMessage(recentMessage))) {
+      console.log("Could not successfully unsend the message! Skipping holder: ", recentMessage);
       continue;
     }
-    console.log('Clicking more button: ', moreButton);
-    moreButton.click();
-
-    // Update the click count for the button. This is used to skip elements
-    // that refuse to be unsent (see: prepareDOMForRemoval -- we remove these
-    // DOM elements there).
-    clickCountPerElement.set(el, (clickCountPerElement.get(el) ?? 0) + 1);
-
-    // Hit the remove button to get the popup.
-    await sleep(500);
-    const removeButton = document.querySelector(REMOVE_BUTTON_QUERY);
-    if (!removeButton) {
-      console.log('No removeButton found! Skipping holder: ', el);
-      continue;
-    }
-
-    console.log('Clicking remove button: ', removeButton);
-    removeButton.click();
-
-    // Hit unsend on the popup. If we are in debug mode, just log the popup.
-    await sleep(1000);
-    const unsendButton = document.querySelector(REMOVE_CONFIRMATION_QUERY);
-    const cancelButton = document.querySelector(CANCEL_CONFIRMATION_QUERY);
-    if (DEBUG_MODE) {
-      console.log('Skipping unsend because we are in debug mode.', unsendButton);
-      cancelButton.click();
-    } else if (!unsendButton) {
-      console.log('No unsendButton found! Skipping holder: ', el);
-      cancelButton.click();
-    } else {
-      console.log('Clicking unsend button: ', unsendButton);
-      unsendButton.click();
-    }
-    await sleep(1800);
   }
-  console.log('Removed all holders.');
+  console.log("Removed all holders.");
 
   // Now see if we need to scroll up.
-  const scroller_ = getScroller();
-  const topOfChainText = document.querySelectorAll(TOP_OF_CHAIN_QUERY);
-  await sleep(2000);
-  if (!scroller_ || scroller_.scrollTop === 0) {
-    console.log('Reached top of chain: ', topOfChainText);
+  const topOfChainText = document.querySelector(TOP_OF_CHAIN_QUERY);
+  if ((!scroller_ || scroller_.scrollTop === 0) && Boolean(topOfChainText)) {
+    console.log("Reached top of chain: ", topOfChainText);
     return { status: STATUS.COMPLETE };
   }
 
   // Scroll up. Wait for the loader.
   // Were done loading when the loading animation is gone, or when the loop
-  // waits 5 times (10s).
+  // waits 10 times (10s).
   let loader = null;
   scroller_.scrollTop = 0;
-
-  for (let i = 0; i < 5; ++i) {
-    console.log('Waiting for loading messages to populate...', loader);
-    await sleep(2000);
+  for (let i = 0; i < 10; ++i) {
+    console.log("Waiting for loading messages to populate...", loader);
+    await sleep(1000);
     loader = document.querySelector(LOADING_QUERY);
     if (!loader) break;
   }
@@ -270,150 +335,64 @@ async function unsendAllVisibleMessages() {
   return { status: STATUS.CONTINUE, data: DELAY * 1000 };
 }
 
-async function deleteAllRunner(count) {
-  console.log('Starting delete all runner removal for N iterations: ', count);
-  for (let i = 0; i < count; ++i) {
-    console.log('Running count:', i);
-    const sleepTime = await unsendAllVisibleMessages();
-    if (sleepTime.status === STATUS.CONTINUE) {
-      console.log('Sleeping to avoid rate limits: ', sleepTime.data / 1000);
-      await sleep(sleepTime.data);
-    } else if (sleepTime.status === STATUS.COMPLETE) {
-      return STATUS.COMPLETE;
-    } else {
-      return STATUS.ERROR;
-    }
+async function deleteAllRunner() {
+  console.log("Starting delete all runner removal");
+  let sleepTime = await unsendAllVisibleMessages();
+  while (sleepTime.status === STATUS.CONTINUE) {
+    console.log(`Sleeping to avoid rate limits: ${sleepTime.data / 1000}`);
+    await sleep(sleepTime.data);
+    sleepTime = await unsendAllVisibleMessages();
   }
-  console.log('Completed run.');
-  return STATUS.CONTINUE;
+  return sleepTime.status;
 }
 
-function hijackLog() {
-  // Add a log to the bottom left of the screen where users can see what the
-  // system is thinking about.
-  console.log('Adding log to screen');
-  const log = document.createElement('div');
-  log.id = 'log';
-  log.style.position = 'fixed';
-  log.style.bottom = '0';
-  log.style.left = '0';
-  log.style.backgroundColor = 'white';
-  log.style.padding = '10px';
-  log.style.zIndex = '10000';
-  log.style.maxWidth = '200px';
-  log.style.maxHeight = '500px';
-  log.style.overflow = 'scroll';
-  log.style.border = '1px solid black';
-  log.style.fontSize = '12px';
-  log.style.fontFamily = 'monospace';
-  log.style.color = 'black';
-  document.body.appendChild(log);
-
-  // Hijack the console.log function to also append to our new log element.
-  const oldLog = console.log;
-  console.log = function () {
-    oldLog.apply(console, arguments);
-    log.innerText += '\n' + Array.from(arguments).join(' ');
-    log.scrollTop = log.scrollHeight;
-  };
-  console.log('Successfully added log to screen');
-  console.log(
-    'To see more complete logs, hit f12 or open the developer console.',
-  );
-  return log;
-}
 
 async function removeHandler() {
-  hijackLog();
-  DELAY = localStorage.getItem(delayKey) || DELAY;
-  console.log('Sleeping to allow the page to load fully...');
+  console.log("Sleeping to allow the page to load fully...");
   await sleep(10000); // give the page a bit to fully load.
 
-  const status = await deleteAllRunner(RUNNER_COUNT);
+  const status = await deleteAllRunner();
 
   if (status === STATUS.COMPLETE) {
-    localStorage.removeItem(continueKey);
-    console.log('Success!');
-    alert('Successfully cleared all messages!');
+    console.log("Success!");
+    alert("Successfully cleared all messages!");
     return null;
-  } else if (status === STATUS.CONTINUE) {
-    console.log('Completed runner iteration but did not finish removal.');
-    localStorage.setItem(continueKey, true);
-    return reload();
   }
-
-  console.log('Failed to complete removal.');
-  alert('ERROR: something went wrong. Failed to complete removal.');
+  if (status === STATUS.STOPPED) {
+    console.log("Deleting process was stopped");
+    alert("Deleting process was stopped");
+    return null
+  }
+  console.log("Failed to complete removal.");
+  alert("ERROR: something went wrong. Failed to complete removal.");
 }
 
 // Main ----------------------------------------------------------------------
 
-// Hacky fix to avoid issues with removing/manipulating the DOM from outside
-// react control.
-// See: https://github.com/facebook/react/issues/11538#issuecomment-417504600
-if (typeof Node === 'function' && Node.prototype) {
-  const originalRemoveChild = Node.prototype.removeChild;
-  Node.prototype.removeChild = function (child) {
-    if (child.parentNode !== this) {
-      if (console) {
-        console.error(
-          'Cannot remove a child from a different parent',
-          child,
-          this,
-        );
-      }
-      return child;
-    }
-    return originalRemoveChild.apply(this, arguments);
-  };
-
-  const originalInsertBefore = Node.prototype.insertBefore;
-  Node.prototype.insertBefore = function (newNode, referenceNode) {
-    if (referenceNode && referenceNode.parentNode !== this) {
-      if (console) {
-        console.error(
-          'Cannot insert before a reference node from a different parent',
-          referenceNode,
-          this,
-        );
-      }
-      return newNode;
-    }
-    return originalInsertBefore.apply(this, arguments);
-  };
-}
-
 browser.runtime.onMessage.addListener((msg, sender) => {
   // Make sure we are using english language messenger.
-  if (document.documentElement.lang !== 'en') {
+  if (document.documentElement.lang !== "en") {
     alert(
-      'ERROR: detected non-English language. Fire Messenger only works when Facebook settings are set to English. Please change your profile settings and try again.',
+      "ERROR: detected non-English language. Fire Messenger only works when Facebook settings are set to English. Please change your profile settings and try again.",
     );
     return;
   }
 
-  console.log('Got action: ', msg.action);
-  if (msg.action === 'REMOVE') {
+  console.log("Got action: ", msg.action);
+  if (msg.action === "REMOVE") {
     const doRemove = confirm(
-      'Removal will nuke your messages and will prevent you from seeing the messages of other people in this chat. We HIGHLY recommend backing up your messages first. Continue?',
+      "Removal will nuke your messages and will prevent you from seeing the messages of other people in this chat. We HIGHLY recommend backing up your messages first. Continue?",
     );
     if (doRemove) {
+      console.log(`Setting delay to ${msg.data} seconds.`);
+      DELAY = msg.data || DELAY;
+      STOP = false;
       removeHandler();
     }
-  } else if (msg.action === 'STOP') {
-    localStorage.removeItem(continueKey);
-    reload();
-  } else if (msg.action === 'UPDATE_DELAY') {
-    console.log('Setting delay to', msg.data || DELAY, 'seconds');
-    localStorage.setItem(delayKey, msg.data);
+  } else if (msg.action === "STOP") {
+    console.log(`Received Stopped signal`);
+    STOP = true;
   } else {
-    console.log('Unknown action.');
+    console.log("Unknown action.");
   }
 });
-
-console.log("Checking if we should continue the deletion");
-if (localStorage.getItem(continueKey)) {
-  console.log("Continuing deletion");
-  removeHandler();
-}
-console.log("No continuation");

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,7 +5,7 @@
     <button id="RemoveMessages">Remove Messages</button>
     <button id="Stop">Stop Removal</button>
     <div>Rate limit pause (in seconds)</div>
-    <input type="number" id="Delay" />
+    <input type="number" id="Delay" min="5" value="5"/>
     <div id="Message"></div>
     <script type="application/javascript" src="browser-polyfill.js"></script>
     <script type="module" src="browser-polyfill.js"></script>

--- a/src/popup.js
+++ b/src/popup.js
@@ -20,7 +20,9 @@ function onError(error) {
 // Make sure the user is using messenger.com.
 const messengers = [
   'https://www.messenger.com',
-  'https://messenger.com/'
+  'https://messenger.com',
+  'https://facebook.com/messages',
+  'https://www.facebook.com/messages'
 ];
 
 browser.tabs.query({active: true, currentWindow: true})

--- a/src/popup.js
+++ b/src/popup.js
@@ -27,11 +27,6 @@ browser.tabs.query({active: true, currentWindow: true})
             .then((tabs) => {
               if (!messengers.some((m) => tabs[0].url.startsWith(m))){
                 disablePopupHtml();
-              } else {
-                browser.tabs.sendMessage(tabs[0].id, { 
-                  action: 'UPDATE_DELAY',
-                  data: delayInput.value
-                });
               }
             })
             .catch(onError);
@@ -40,7 +35,11 @@ browser.tabs.query({active: true, currentWindow: true})
 removeMessagesButton.addEventListener('click', () => {
   browser.tabs.query({ active: true, currentWindow: true})
               .then((tabs) => {
-                browser.tabs.sendMessage(tabs[0].id, {action: 'REMOVE'}); 
+                const message = {
+                  action: 'REMOVE',
+                  data: delayInput.value
+                };
+                browser.tabs.sendMessage(tabs[0].id, message);
               })
               .catch(onError);
 });
@@ -48,18 +47,7 @@ removeMessagesButton.addEventListener('click', () => {
 stopButton.addEventListener('click', () => {
   browser.tabs.query({ active: true, currentWindow: true})
               .then((tabs) => {
-                browser.tabs.sendMessage(tabs[0].id, {action: 'STOP'}); 
-              })
-              .catch(onError);
-});
-
-delayInput.addEventListener('input', (e) => {
-  browser.tabs.query({ active: true, currentWindow: true})
-              .then((tabs) => {
-                browser.tabs.sendMessage(tabs[0].id, { 
-                  action: 'UPDATE_DELAY',
-                  data: e.target.value
-                });
+                browser.tabs.sendMessage(tabs[0].id, {action: 'STOP'});
               })
               .catch(onError);
 });


### PR DESCRIPTION
### Version 1.1.0:

- Allowed the JavaScript content script to be injected to `facebook.com/messages` as per #2.
- Removed the use of [`localStorage` API](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
- Made the removal of reaction and messages more robust by creating more checks after the removal.
- Changed the removal order of messages to allow for a more 'fluid' removal process.
- Removed the 'logging' window that was injected into the website's DOM to avoid unnecessary bloat.
- General bug fixes